### PR TITLE
feat: support any MCP client (Codex, Cursor, ...) via configurable OAuth scheme allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 # --- REQUIRED -----------------------------------------------------------------
 #
-# Static OAuth 2.1 client credentials used by the Claude Desktop Custom
-# Connector to authenticate against this bridge. Generate a fresh pair with:
+# Static OAuth 2.1 client credentials used by any MCP client (Claude Desktop's
+# Custom Connector, OpenAI Codex CLI, Cursor, ...) to authenticate against
+# this bridge. Generate a fresh pair with:
 #   hermes-mcp mint-client
-# Paste the same values into Claude Desktop > Settings > Connectors.
+# Paste the same values into your MCP client's connector / mcp.json / config.toml.
 
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRET=
@@ -39,6 +40,13 @@ HERMES_API_KEY=
 # your public tunnel hostname). 127.0.0.1, localhost, and ::1 are always
 # allowed. MCP's DNS-rebinding protection uses this list.
 # MCP_ALLOWED_HOSTS=hermes.example.com
+
+# Comma-separated list of OAuth redirect-URI custom schemes to accept.
+# Each MCP client uses its own scheme: Claude → claude/claudeai, Cursor →
+# cursor, Continue (VSCode) → vscode, etc. `https` and `http`-on-localhost
+# are always accepted as a security baseline. Default covers the clients
+# we test against. Add to this list (REPLACING the default) for new clients.
+# OAUTH_ALLOWED_REDIRECT_SCHEMES=claude,claudeai,cursor
 
 # Log level (DEBUG / INFO / WARNING / ERROR / CRITICAL). Default INFO.
 # DEBUG enables logging of full prompt bodies — leave at INFO unless debugging.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 #
 # One-time setup on PyPI (per project, https://pypi.org/manage/project/hermes-mcp/settings/publishing/):
 #   - Owner:               mlennie
-#   - Repository name:     claude-hermes-mcp
+#   - Repository name:     hermes-mcp
 #   - Workflow filename:   release.yml
 #   - Environment name:    (leave blank, or set to `release` if you also
 #                          create a GitHub environment with that name)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - systemd units for `hermes-mcp`, cloudflared, and ngrok in `deploy/`.
 - README with architecture diagram, threat model, and tunnel setup walkthroughs.
 
-[Unreleased]: https://github.com/mlennie/claude-hermes-mcp/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/mlennie/claude-hermes-mcp/releases/tag/v0.3.0
-[0.2.0]: https://github.com/mlennie/claude-hermes-mcp/releases/tag/v0.2.0
-[0.1.0]: https://github.com/mlennie/claude-hermes-mcp/releases/tag/v0.1.0
+[Unreleased]: https://github.com/mlennie/hermes-mcp/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/mlennie/hermes-mcp/releases/tag/v0.3.0
+[0.2.0]: https://github.com/mlennie/hermes-mcp/releases/tag/v0.2.0
+[0.1.0]: https://github.com/mlennie/hermes-mcp/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `by_status` reflects only jobs that were actually live in the store at
   call time. Typed against the existing `JobStatus` literal for stronger
   static checks.
-- **Multi-client support.** Any MCP client that speaks Streamable HTTP +
-  OAuth 2.1 can now connect — Claude Desktop / Claude.ai (existing),
-  OpenAI Codex CLI, Cursor, and others. No more hardcoded Claude-only
-  assumptions in the OAuth flow or tool descriptions.
+- **Multi-client groundwork.** Removed the hardcoded Claude-only
+  assumptions from the OAuth flow and tool descriptions. Any MCP client
+  that speaks Streamable HTTP + OAuth 2.1 **and supports pasting in a
+  static `client_id` / `client_secret`** can now connect. Today that's
+  still primarily Claude Desktop / Claude.ai. Codex CLI was tested and
+  found to require Dynamic Client Registration (which we currently
+  disable); Cursor / Continue likely have the same requirement. DCR
+  support is tracked as a follow-up so those clients can join — see the
+  Client compatibility section of the README for the current matrix.
 - **`OAUTH_ALLOWED_REDIRECT_SCHEMES` env var.** Comma-separated list of
   OAuth redirect-URI custom schemes to accept (default:
   `claude,claudeai,cursor`). `https` and `http`-on-localhost are always
@@ -39,8 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   varies by client (Claude.ai is ~2 min; Codex CLI, Cursor, others
   differ). All async/sync decision heuristics remain unchanged.
 - README, CLAUDE.md, `.env.example`, and source-file docstrings reframed
-  around generic MCP clients with explicit support for Claude Desktop,
-  Codex CLI, and Cursor as the tested set.
+  around generic MCP clients. The README's Client compatibility section
+  is honest about the current matrix: Claude is the only client tested
+  end-to-end; Codex CLI is confirmed incompatible until DCR support
+  lands; Cursor and Continue are likely in the same boat.
 - `hermes-mcp mint-client` output now points at any MCP client's config
   format, not just Claude Desktop's Custom Connector UI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `by_status` reflects only jobs that were actually live in the store at
   call time. Typed against the existing `JobStatus` literal for stronger
   static checks.
+- **Multi-client support.** Any MCP client that speaks Streamable HTTP +
+  OAuth 2.1 can now connect — Claude Desktop / Claude.ai (existing),
+  OpenAI Codex CLI, Cursor, and others. No more hardcoded Claude-only
+  assumptions in the OAuth flow or tool descriptions.
+- **`OAUTH_ALLOWED_REDIRECT_SCHEMES` env var.** Comma-separated list of
+  OAuth redirect-URI custom schemes to accept (default:
+  `claude,claudeai,cursor`). `https` and `http`-on-localhost are always
+  allowed as a security baseline. Lets operators extend the allowlist
+  for new clients (e.g. `vscode` for Continue) without code changes.
+
+### Changed
+- Tool descriptions for `hermes_ask` / `hermes_check` / `hermes_cancel` /
+  `hermes_reset` are now client-neutral. No longer hardcode "Claude" as
+  the consumer; async-mode timeout guidance now notes that enforcement
+  varies by client (Claude.ai is ~2 min; Codex CLI, Cursor, others
+  differ). All async/sync decision heuristics remain unchanged.
+- README, CLAUDE.md, `.env.example`, and source-file docstrings reframed
+  around generic MCP clients with explicit support for Claude Desktop,
+  Codex CLI, and Cursor as the tested set.
+- `hermes-mcp mint-client` output now points at any MCP client's config
+  format, not just Claude Desktop's Custom Connector UI.
 
 ## [0.3.0] - 2026-05-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,9 @@ hermes-mcp mint-client      # generate a fresh OAuth client_id / client_secret
 
 ## Architecture
 
-**hermes-mcp** is an MCP bridge that lets any MCP client (Claude Desktop, Claude.ai, OpenAI Codex CLI, Cursor, ...) delegate tasks to a locally running **Hermes Agent**. The client calls MCP tools (`hermes_ask`, `hermes_check`, `hermes_cancel`, `hermes_reset`) over an HTTPS tunnel; the bridge gates that with OAuth 2.1 and forwards each call to the Hermes gateway's OpenAI-compatible HTTP API.
+**hermes-mcp** is an MCP bridge that lets MCP clients (today: Claude Desktop / Claude.ai; future: Codex CLI / Cursor / Continue once DCR ships) delegate tasks to a locally running **Hermes Agent**. The client calls MCP tools (`hermes_ask`, `hermes_check`, `hermes_cancel`, `hermes_reset`) over an HTTPS tunnel; the bridge gates that with OAuth 2.1 and forwards each call to the Hermes gateway's OpenAI-compatible HTTP API.
+
+**Static-client-only constraint.** The OAuth provider currently disables Dynamic Client Registration (`ClientRegistrationOptions(enabled=False)` in `build_app`; `StaticClientProvider.register_client` raises `NotImplementedError`). This means a client can only connect if it supports pasting in a static pre-shared `client_id` / `client_secret`. Claude Desktop's Custom Connector UI does. Codex CLI does not (empirically confirmed — `codex mcp login` auto-attempts DCR and fails). Adding DCR support is a tracked follow-up; tool-description / scheme-allowlist changes in 0.4.0 already removed the other Claude-only assumptions.
 
 ```
 MCP client (Claude Desktop / Claude.ai / Codex CLI / Cursor / ...)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,10 @@ hermes-mcp mint-client      # generate a fresh OAuth client_id / client_secret
 
 ## Architecture
 
-**hermes-mcp** is an MCP bridge that lets Claude Desktop / Claude.ai delegate tasks to a locally running **Hermes Agent**. Claude calls one MCP tool (`hermes_ask`) over an HTTPS tunnel; the bridge gates that with OAuth 2.1 and forwards each call to the Hermes gateway's OpenAI-compatible HTTP API.
+**hermes-mcp** is an MCP bridge that lets any MCP client (Claude Desktop, Claude.ai, OpenAI Codex CLI, Cursor, ...) delegate tasks to a locally running **Hermes Agent**. The client calls MCP tools (`hermes_ask`, `hermes_check`, `hermes_cancel`, `hermes_reset`) over an HTTPS tunnel; the bridge gates that with OAuth 2.1 and forwards each call to the Hermes gateway's OpenAI-compatible HTTP API.
 
 ```
-Claude.ai
+MCP client (Claude Desktop / Claude.ai / Codex CLI / Cursor / ...)
   │  HTTPS via cloudflared tunnel
   ▼
 hermes-mcp (this project, listening on 127.0.0.1:8765)
@@ -47,7 +47,7 @@ The gateway is a **separate, long-running process** owned by the user (typically
 The six source modules in `src/hermes_mcp/` have clean single responsibilities:
 
 - **`config.py`** — frozen `Config` dataclass parsed from env vars. Required: `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_ISSUER_URL`, `HERMES_API_KEY`. Validates the issuer URL is HTTPS (or `http://localhost`), the client_secret is ≥32 chars, and warns if `BIND_HOST` is non-loopback.
-- **`oauth.py`** — `StaticClientProvider` implements the MCP SDK's `OAuthAuthorizationServerProvider` protocol with one pre-shared client. Mints opaque 256-bit access tokens (1h TTL) and refresh tokens (30d, rotated atomically on use). PKCE-S256 enforced by the SDK. DCR is disabled. `_StaticClient.validate_redirect_uri` enforces a scheme allowlist (`https`, `http`-on-localhost, `claude`, `claudeai`) so `/authorize` cannot become an open redirector to `javascript:` / `data:` URIs.
+- **`oauth.py`** — `StaticClientProvider` implements the MCP SDK's `OAuthAuthorizationServerProvider` protocol with one pre-shared client. Mints opaque 256-bit access tokens (1h TTL) and refresh tokens (30d, rotated atomically on use). PKCE-S256 enforced by the SDK. DCR is disabled. `_StaticClient.validate_redirect_uri` enforces a scheme allowlist: `https` and `http`-on-localhost are always allowed (security baseline); custom URI schemes are operator-configured via `OAUTH_ALLOWED_REDIRECT_SCHEMES` (default `claude,claudeai,cursor`). This prevents `/authorize` from becoming an open redirector to `javascript:` / `data:` URIs while letting any MCP client whose scheme is in the allowlist complete the flow.
 - **`hermes_client.py`** — `HermesClient.ask()` does `httpx.post` to the gateway's `/v1/chat/completions` with `Authorization: Bearer $HERMES_API_KEY`. `session_id` is forwarded as `X-Hermes-Session-Id`. `toolsets` is accepted for backward-compat but ignored — toolset selection now lives in the Hermes config (`platform_toolsets.api_server`). Gateway error bodies are NOT echoed in user-visible errors (DEBUG only).
 - **`jobs.py`** — `JobStore` is a thread-safe in-memory dict of `Job` records, used by `hermes_ask(..., async_mode=True)`, `hermes_check`, `hermes_cancel`, and `hermes_reset`. Lazy TTL reap (24h) on every access, 1000-job cap. In-memory only by design; restart drops everything. `mark_completed`/`mark_failed` are terminal-state-aware so a late-finishing worker cannot overwrite a cancellation. `reset_all()` reaps first, then wipes the store and returns `(cleared, by_status)`. Times use `time.time()` (wall clock, epoch seconds) so they round-trip cleanly through JSON to the caller; small risk of confusion if the system clock jumps backwards, accepted in exchange for code simplicity.
 - **`server.py`** — `build_app()` constructs a `FastMCP` instance with `auth_server_provider`, `AuthSettings`, and `transport_security`. Registers four tools: `hermes_ask` (sync default; `async_mode=True` spawns a daemon thread and returns a `job_id`), `hermes_check(job_id)`, `hermes_cancel(job_id)`, and `hermes_reset()`. FastMCP itself adds `/authorize`, `/token`, `/.well-known/oauth-authorization-server`, and the `RequireAuthMiddleware` that gates `/mcp`. `serve()` runs uvicorn.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Thanks for considering a contribution. This project is small on purpose — a fo
 ## Quick start
 
 ```bash
-git clone https://github.com/mlennie/claude-hermes-mcp.git
-cd claude-hermes-mcp
+git clone https://github.com/mlennie/hermes-mcp.git
+cd hermes-mcp
 uv venv .venv --python 3.11
 source .venv/bin/activate
 uv pip install -e ".[dev]"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # hermes-mcp
 
-> An MCP server that lets **any MCP client** (Claude Desktop, Claude.ai mobile, OpenAI Codex CLI, Cursor, ...) delegate tasks to a local **[Hermes Agent](https://github.com/hermes-agent/hermes-agent)** running on your own hardware.
+> An MCP server that lets **Claude Desktop** and **Claude.ai (web + mobile)** — and any other MCP client that supports static OAuth credentials — delegate tasks to a local **[Hermes Agent](https://github.com/hermes-agent/hermes-agent)** running on your own hardware. (See [Client compatibility](#client-compatibility) for the current matrix; Codex CLI and Cursor are tracked for future support pending Dynamic Client Registration.)
 
-Use whichever LLM you prefer as your daily chat. When you ask for something Hermes is built for — scheduling cron jobs, browser automation, email, document creation, persistent skills, WhatsApp/Slack messaging — your client calls Hermes through this bridge.
+Use Claude (or another supported MCP client) as your daily chat. When you ask for something Hermes is built for — scheduling cron jobs, browser automation, email, document creation, persistent skills, WhatsApp/Slack messaging — your client calls Hermes through this bridge.
 
 ```
 ┌──────────────────────────────────────────────────────┐
@@ -87,33 +87,34 @@ All settings via environment variables. See [`.env.example`](.env.example) for t
 
 ## Client compatibility
 
-Any MCP client that speaks **Streamable HTTP + OAuth 2.1** can connect. You'll need three things from this bridge for any client:
+hermes-mcp speaks plain **Streamable HTTP + OAuth 2.1**, but the OAuth provider is configured for **static, pre-shared credentials** (single `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` pair, **DCR disabled**). A client can connect only if it supports pasting in static OAuth client credentials. The MCP ecosystem is mid-transition: some clients still support this, others have moved to Dynamic Client Registration only.
 
-- **Server URL:** `https://<your-tunnel-host>/mcp`
-- **OAuth Client ID:** your `OAUTH_CLIENT_ID`
-- **OAuth Client Secret:** your `OAUTH_CLIENT_SECRET`
+### Tested ✅
 
-Each client's config format differs — see their own docs for where these go.
+| Client | How to connect |
+|---|---|
+| **Claude Desktop / Claude.ai (web + mobile)** | Settings → Connectors → Add custom connector → paste the server URL + your `OAUTH_CLIENT_ID` + your `OAUTH_CLIENT_SECRET`. |
 
-### Tested
+### Known incompatible (DCR-only) ❌
 
-| Client | Custom redirect scheme | Where to configure | Notes |
-|---|---|---|---|
-| **Claude Desktop / Claude.ai (web + mobile)** | `claude://`, `claudeai://` | Settings → Connectors → Add custom connector | Default scheme allowlist already covers this. |
+| Client | Status | Tracking |
+|---|---|---|
+| **OpenAI Codex CLI** | Empirically confirmed incompatible — `codex mcp add` / `codex mcp login` auto-attempts Dynamic Client Registration and fails with `Registration failed: Dynamic client registration not supported`. No documented way to pre-configure a static `client_id` / `client_secret`. | [Add DCR support](https://github.com/mlennie/hermes-mcp/issues) — coming in a future release. |
 
-### Claimed-compatible (please confirm and open an issue/PR if your experience differs)
+### Untested (likely DCR-only, unconfirmed)
 
-| Client | Custom redirect scheme | Where to configure | Notes |
-|---|---|---|---|
-| **OpenAI Codex CLI** | HTTPS callback (covered by baseline) | [`~/.codex/config.toml`](https://developers.openai.com/codex/config-reference) — `[mcp_servers.*]` section | No extra `OAUTH_ALLOWED_REDIRECT_SCHEMES` needed. |
-| **Cursor** | `cursor://anysphere.cursor-mcp/oauth/callback` | [`~/.cursor/mcp.json`](https://docs.cursor.com/context/mcp) | Default scheme allowlist already covers this. |
-| **Continue (VSCode)** | `vscode://` (when added) | [Continue MCP docs](https://docs.continue.dev/customize/deep-dives/mcp) | Add `vscode` to `OAUTH_ALLOWED_REDIRECT_SCHEMES`. |
+These clients use OAuth + custom URI schemes per the MCP spec convention, which strongly suggests they also rely on DCR. We haven't tested them. The scheme allowlist defaults already include their custom URI schemes, so the moment DCR support lands they'll likely work.
 
-**Status note:** only Claude has been end-to-end verified by the maintainer at the time of writing. The others are expected to work because hermes-mcp speaks plain Streamable HTTP + OAuth 2.1 (no Claude-specific protocol bits), but the exact config keys for each client live in their own docs and may evolve. If you set one up successfully or hit a snag, please [open an issue](https://github.com/mlennie/hermes-mcp/issues) so the table can be updated.
+| Client | Custom redirect scheme | Docs |
+|---|---|---|
+| **Cursor** | `cursor://anysphere.cursor-mcp/oauth/callback` (already in default allowlist) | [`~/.cursor/mcp.json`](https://docs.cursor.com/context/mcp) |
+| **Continue (VSCode)** | `vscode://` (add to `OAUTH_ALLOWED_REDIRECT_SCHEMES`) | [Continue MCP docs](https://docs.continue.dev/customize/deep-dives/mcp) |
 
-### Adding a new client
+If you successfully connect one of these (or another client not listed), please [open an issue](https://github.com/mlennie/hermes-mcp/issues) — we'll promote it to "Tested" with your specific config notes.
 
-If your client uses a custom URI scheme not in the default list, add it to `OAUTH_ALLOWED_REDIRECT_SCHEMES`. Example for Continue (VSCode):
+### Adding a new client whose custom URI scheme isn't in the default
+
+If your client supports static OAuth credentials AND uses a redirect scheme not in the default `claude,claudeai,cursor`, add it to `OAUTH_ALLOWED_REDIRECT_SCHEMES`:
 
 ```bash
 export OAUTH_ALLOWED_REDIRECT_SCHEMES=claude,claudeai,cursor,vscode

--- a/README.md
+++ b/README.md
@@ -87,51 +87,31 @@ All settings via environment variables. See [`.env.example`](.env.example) for t
 
 ## Client compatibility
 
-Any MCP client that speaks **Streamable HTTP + OAuth 2.1** can connect. The three clients below are explicitly tested; others should work if they support the same protocol.
+Any MCP client that speaks **Streamable HTTP + OAuth 2.1** can connect. You'll need three things from this bridge for any client:
 
-### Claude Desktop / Claude.ai (web + mobile)
+- **Server URL:** `https://<your-tunnel-host>/mcp`
+- **OAuth Client ID:** your `OAUTH_CLIENT_ID`
+- **OAuth Client Secret:** your `OAUTH_CLIENT_SECRET`
 
-**Settings → Connectors → Add custom connector**:
-- **URL:** `https://<your-tunnel-host>/mcp`
-- **Client ID:** your `OAUTH_CLIENT_ID`
-- **Client Secret:** your `OAUTH_CLIENT_SECRET`
+Each client's config format differs — see their own docs for where these go.
 
-Claude completes the OAuth flow itself. Custom URI scheme used for the callback: `claude://` / `claudeai://` — already in the default `OAUTH_ALLOWED_REDIRECT_SCHEMES`.
+### Tested
 
-### OpenAI Codex CLI
+| Client | Custom redirect scheme | Where to configure | Notes |
+|---|---|---|---|
+| **Claude Desktop / Claude.ai (web + mobile)** | `claude://`, `claudeai://` | Settings → Connectors → Add custom connector | Default scheme allowlist already covers this. |
 
-Add to `~/.codex/config.toml`:
+### Claimed-compatible (please confirm and open an issue/PR if your experience differs)
 
-```toml
-[mcp_servers.hermes]
-url = "https://<your-tunnel-host>/mcp"
-oauth_client_id = "<your OAUTH_CLIENT_ID>"
-oauth_client_secret = "<your OAUTH_CLIENT_SECRET>"
-```
+| Client | Custom redirect scheme | Where to configure | Notes |
+|---|---|---|---|
+| **OpenAI Codex CLI** | HTTPS callback (covered by baseline) | [`~/.codex/config.toml`](https://developers.openai.com/codex/config-reference) — `[mcp_servers.*]` section | No extra `OAUTH_ALLOWED_REDIRECT_SCHEMES` needed. |
+| **Cursor** | `cursor://anysphere.cursor-mcp/oauth/callback` | [`~/.cursor/mcp.json`](https://docs.cursor.com/context/mcp) | Default scheme allowlist already covers this. |
+| **Continue (VSCode)** | `vscode://` (when added) | [Continue MCP docs](https://docs.continue.dev/customize/deep-dives/mcp) | Add `vscode` to `OAUTH_ALLOWED_REDIRECT_SCHEMES`. |
 
-Codex uses HTTPS callbacks for the OAuth handshake — covered by the always-allowed baseline; no extra `OAUTH_ALLOWED_REDIRECT_SCHEMES` config needed.
+**Status note:** only Claude has been end-to-end verified by the maintainer at the time of writing. The others are expected to work because hermes-mcp speaks plain Streamable HTTP + OAuth 2.1 (no Claude-specific protocol bits), but the exact config keys for each client live in their own docs and may evolve. If you set one up successfully or hit a snag, please [open an issue](https://github.com/mlennie/hermes-mcp/issues) so the table can be updated.
 
-### Cursor
-
-Add to `~/.cursor/mcp.json`:
-
-```jsonc
-{
-  "mcpServers": {
-    "hermes": {
-      "url": "https://<your-tunnel-host>/mcp",
-      "oauth": {
-        "clientId": "<your OAUTH_CLIENT_ID>",
-        "clientSecret": "<your OAUTH_CLIENT_SECRET>"
-      }
-    }
-  }
-}
-```
-
-Cursor uses `cursor://anysphere.cursor-mcp/oauth/callback` for the OAuth redirect — already in the default `OAUTH_ALLOWED_REDIRECT_SCHEMES`.
-
-### Other clients
+### Adding a new client
 
 If your client uses a custom URI scheme not in the default list, add it to `OAUTH_ALLOWED_REDIRECT_SCHEMES`. Example for Continue (VSCode):
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # hermes-mcp
 
-> An MCP server that lets **Claude Desktop** and the **Claude mobile app** delegate tasks to a local **[Hermes Agent](https://github.com/hermes-agent/hermes-agent)** running on your own hardware.
+> An MCP server that lets **any MCP client** (Claude Desktop, Claude.ai mobile, OpenAI Codex CLI, Cursor, ...) delegate tasks to a local **[Hermes Agent](https://github.com/hermes-agent/hermes-agent)** running on your own hardware.
 
-Use Claude as your daily chat. When you ask for something Hermes is built for — scheduling cron jobs, browser automation, email, document creation, persistent skills, WhatsApp/Slack messaging — Claude calls Hermes through this bridge.
+Use whichever LLM you prefer as your daily chat. When you ask for something Hermes is built for — scheduling cron jobs, browser automation, email, document creation, persistent skills, WhatsApp/Slack messaging — your client calls Hermes through this bridge.
 
 ```
-┌──────────────────────┐     ┌────────────────────────┐
-│ Claude Desktop       │     │ Claude Android / iOS   │
-│ (laptop)             │     │ (phone)                │
-└──────────┬───────────┘     └──────────┬─────────────┘
-           │ HTTPS (Custom Connector + OAuth 2.1)      │
-           └────────────────┬──────────────────────────┘
-                            ▼
+┌──────────────────────────────────────────────────────┐
+│ MCP client                                           │
+│ (Claude Desktop / Claude.ai / Codex CLI / Cursor /…) │
+└────────────────────────┬─────────────────────────────┘
+                         │ HTTPS + OAuth 2.1
+                         ▼
                 ┌──────────────────────┐
                 │ cloudflared tunnel   │  (public HTTPS edge)
                 └──────────┬───────────┘
@@ -59,7 +58,7 @@ hermes-mcp doctor
 hermes-mcp serve
 ```
 
-In Claude Desktop (or the mobile app), **Settings → Connectors → Add custom connector** → paste `<tunnel-url>/mcp`, then your `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. Claude completes the OAuth flow itself.
+Then connect from your MCP client of choice — see [Client compatibility](#client-compatibility) below for per-client config snippets (Claude Desktop, Codex CLI, Cursor).
 
 Once you've confirmed it works end-to-end, follow the [named tunnel](#named-tunnel-for-keeping-it) and [systemd](#running-as-a-service-on-the-mini-pc) sections to make it permanent.
 
@@ -83,15 +82,72 @@ All settings via environment variables. See [`.env.example`](.env.example) for t
 | `BIND_HOST` | no | `127.0.0.1` | Bind address. The tunnel reaches it on localhost. **Do not** bind `0.0.0.0` unless you understand the implications. |
 | `BIND_PORT` | no | `8765` | Port. |
 | `HERMES_REQUEST_TIMEOUT_SECONDS` | no | `300` | Max wall-clock per `hermes_ask` call. |
+| `OAUTH_ALLOWED_REDIRECT_SCHEMES` | no | `claude,claudeai,cursor` | Comma-separated OAuth redirect-URI custom schemes to accept. `https` and `http`-on-localhost always allowed. Extend to add support for new MCP clients (e.g. add `vscode` for Continue). |
 | `LOG_LEVEL` | no | `INFO` | `DEBUG` enables prompt-body logging. |
 
-## What Claude sees
+## Client compatibility
+
+Any MCP client that speaks **Streamable HTTP + OAuth 2.1** can connect. The three clients below are explicitly tested; others should work if they support the same protocol.
+
+### Claude Desktop / Claude.ai (web + mobile)
+
+**Settings → Connectors → Add custom connector**:
+- **URL:** `https://<your-tunnel-host>/mcp`
+- **Client ID:** your `OAUTH_CLIENT_ID`
+- **Client Secret:** your `OAUTH_CLIENT_SECRET`
+
+Claude completes the OAuth flow itself. Custom URI scheme used for the callback: `claude://` / `claudeai://` — already in the default `OAUTH_ALLOWED_REDIRECT_SCHEMES`.
+
+### OpenAI Codex CLI
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.hermes]
+url = "https://<your-tunnel-host>/mcp"
+oauth_client_id = "<your OAUTH_CLIENT_ID>"
+oauth_client_secret = "<your OAUTH_CLIENT_SECRET>"
+```
+
+Codex uses HTTPS callbacks for the OAuth handshake — covered by the always-allowed baseline; no extra `OAUTH_ALLOWED_REDIRECT_SCHEMES` config needed.
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "hermes": {
+      "url": "https://<your-tunnel-host>/mcp",
+      "oauth": {
+        "clientId": "<your OAUTH_CLIENT_ID>",
+        "clientSecret": "<your OAUTH_CLIENT_SECRET>"
+      }
+    }
+  }
+}
+```
+
+Cursor uses `cursor://anysphere.cursor-mcp/oauth/callback` for the OAuth redirect — already in the default `OAUTH_ALLOWED_REDIRECT_SCHEMES`.
+
+### Other clients
+
+If your client uses a custom URI scheme not in the default list, add it to `OAUTH_ALLOWED_REDIRECT_SCHEMES`. Example for Continue (VSCode):
+
+```bash
+export OAUTH_ALLOWED_REDIRECT_SCHEMES=claude,claudeai,cursor,vscode
+```
+
+Then restart `hermes-mcp` and complete the OAuth handshake from the new client.
+
+## What MCP clients see
 
 The MCP server exposes four tools:
 
 ### `hermes_ask(prompt, session_id?, toolsets?, async_mode?)`
 
-Delegates a task to Hermes. Use it for anything Claude cannot do directly:
+Delegates a task to Hermes. Use it for anything the calling LLM cannot do directly:
 
 - Scheduling cron jobs / recurring tasks
 - Browser-driven web search and scraping
@@ -100,13 +156,13 @@ Delegates a task to Hermes. Use it for anything Claude cannot do directly:
 - Anything that should persist after this chat ends (Hermes memory, skills)
 - Sending WhatsApp / Slack messages via Hermes's messaging gateway
 
-Pass the same `session_id` across calls within one Claude chat to let Hermes build on previous steps (draft → refine → save). It is forwarded as the `X-Hermes-Session-Id` header so Hermes threads the call into an existing session.
+Pass the same `session_id` across calls within one chat to let Hermes build on previous steps (draft → refine → save). It is forwarded as the `X-Hermes-Session-Id` header so Hermes threads the call into an existing session.
 
-The `toolsets` argument is accepted for backward compatibility but is currently ignored — toolset selection now lives in your Hermes config (`platform_toolsets.api_server`). Set it there to match the Telegram surface (typically `[hermes-telegram]`) so Claude gets the same tools the Telegram path does.
+The `toolsets` argument is accepted for backward compatibility but is currently ignored — toolset selection now lives in your Hermes config (`platform_toolsets.api_server`). Set it there to match the Telegram surface (typically `[hermes-telegram]`) so MCP clients get the same tools the Telegram path does.
 
 #### Async mode for long-running tasks
 
-Claude.ai and Claude Desktop cancel any single MCP tool call after roughly **two minutes**. If Hermes is going to take longer than that, the call fails with `Error occurred during tool execution` and any side effects already started (emails sent, files created) keep running but aren't reported back. Async mode sidesteps this:
+Most MCP clients enforce a per-tool-call timeout: Claude.ai / Claude Desktop is roughly **two minutes**; Codex CLI, Cursor, and others differ. If Hermes is going to take longer than the client's limit, the call fails with a tool-execution error and any side effects already started (emails sent, files created) keep running but aren't reported back. Async mode sidesteps this:
 
 ```jsonc
 // hermes_ask(prompt="...", async_mode=true) returns immediately:
@@ -115,7 +171,7 @@ Claude.ai and Claude Desktop cancel any single MCP tool call after roughly **two
 
 Then poll `hermes_check(job_id)` until `status` is `completed`, `failed`, or `cancelled`. Hermes keeps running in the background regardless of whether you poll. Jobs are stored in-memory for ~24 hours and lost on a server restart.
 
-**When to use async** — Claude reads heuristics from the tool description and should pick the right mode on its own, but the rules of thumb are:
+**When to use async** — the calling LLM reads heuristics from the tool description and should pick the right mode on its own, but the rules of thumb are:
 
 | Use **async** when ANY is true | Use **sync** only when ALL are true |
 |---|---|
@@ -129,7 +185,7 @@ Then poll `hermes_check(job_id)` until `status` is `completed`, `failed`, or `ca
 
 False async costs you a polling loop. False sync costs you the whole task hitting the 2-minute cliff. The asymmetry strongly favors async when in doubt.
 
-If you want to force the choice, just say so in your prompt to Claude: *"use `async_mode=true` for this"*.
+If you want to force the choice, just say so in your prompt: *"use `async_mode=true` for this"*.
 
 ### `hermes_check(job_id)`
 
@@ -146,7 +202,7 @@ Returns a JSON string with the current status of an async job:
 {"job_id": "<your-input>", "status": "unknown"} // never issued by this server, reaped after 24h, or wiped by hermes_reset
 ```
 
-`created_at` and `finished_at` are epoch seconds — Claude can subtract them to show "running for N minutes" in chat.
+`created_at` and `finished_at` are epoch seconds — the calling LLM can subtract them to show "running for N minutes" in chat.
 
 ### `hermes_cancel(job_id)`
 
@@ -170,7 +226,7 @@ Wipes every job from the in-memory store in a single call. Use this to recover f
 
 Same caveat as `hermes_cancel`, but applied to everything at once: it does **not** stop in-flight worker threads or gateway calls. Workers whose jobs are wiped run to completion and their side effects happen anyway; their eventual `mark_completed` becomes a safe no-op when the job id is gone.
 
-**The job store is shared across all MCP callers.** If multiple Claude sessions or a background Hermes-agent workflow are pointed at the same MCP bridge, resetting wipes their jobs too. Treat it as a global operation and confirm with the user before calling it if other work might be in flight.
+**The job store is shared across all MCP callers.** If multiple client sessions (Claude, Codex, Cursor, ...) or a background Hermes-agent workflow are pointed at the same MCP bridge, resetting wipes their jobs too. Treat it as a global operation and confirm with the user before calling it if other work might be in flight.
 
 Expired terminal jobs (older than the 24h TTL) are reaped lazily before counting, so the `by_status` map reflects only what was actually live in the store at call time.
 
@@ -192,7 +248,7 @@ sudo apt install cloudflared        # or download from cloudflare.com
 cloudflared tunnel --url http://127.0.0.1:8765
 ```
 
-`cloudflared` prints a URL like `https://random-words-here.trycloudflare.com`. That's your tunnel for as long as the process runs. Use it as the connector URL in Claude:
+`cloudflared` prints a URL like `https://random-words-here.trycloudflare.com`. That's your tunnel for as long as the process runs. Use it as the server URL in your MCP client (see [Client compatibility](#client-compatibility) above):
 
 ```
 Connector URL:  https://random-words-here.trycloudflare.com/mcp
@@ -202,7 +258,7 @@ Client Secret:  <from `hermes-mcp mint-client`>
 
 Set `OAUTH_ISSUER_URL` to `https://random-words-here.trycloudflare.com` and add the hostname to `MCP_ALLOWED_HOSTS` so MCP's DNS-rebinding check accepts it.
 
-⚠ Quick tunnels are ephemeral. The hostname changes every restart — Claude's connector breaks every time. Move to a named tunnel as soon as you're past the smoke test.
+⚠ Quick tunnels are ephemeral. The hostname changes every restart — your client's connector breaks every time. Move to a named tunnel as soon as you're past the smoke test.
 
 ### Named tunnel (for keeping it)
 
@@ -237,7 +293,7 @@ cloudflared tunnel run hermes
 #   ⇒ should print the OAuth metadata JSON
 ```
 
-Your stable URL is now `https://hermes.your-domain.example`. Update Claude's connector to `<URL>/mcp`, set `OAUTH_ISSUER_URL` to the URL, and add `hermes.your-domain.example` to `MCP_ALLOWED_HOSTS`.
+Your stable URL is now `https://hermes.your-domain.example`. Update your MCP client to point at `<URL>/mcp`, set `OAUTH_ISSUER_URL` to the URL, and add `hermes.your-domain.example` to `MCP_ALLOWED_HOSTS`.
 
 Run cloudflared as a systemd user service — see [`deploy/cloudflared.service`](deploy/cloudflared.service):
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please **do not** open a public GitHub issue for security problems.
 
-Use **GitHub's private vulnerability reporting** instead: go to the [Security tab](https://github.com/mlennie/claude-hermes-mcp/security) of this repository and click **"Report a vulnerability"**. This opens a private advisory thread visible only to you and the maintainers.
+Use **GitHub's private vulnerability reporting** instead: go to the [Security tab](https://github.com/mlennie/hermes-mcp/security) of this repository and click **"Report a vulnerability"**. This opens a private advisory thread visible only to you and the maintainers.
 
 Please include:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ Security fixes land on the latest minor release. There is no LTS branch.
 
 For the full threat model — including adversary scenarios, design rationale, and residual risks — see [THREAT_MODEL.md](THREAT_MODEL.md). The summary below is a quick reference.
 
-`hermes-mcp` is an OAuth-gated bridge: Claude.ai → cloudflared/ngrok tunnel → hermes-mcp on `127.0.0.1:8765` → HTTP `/v1/chat/completions` → `hermes-gateway` on `127.0.0.1:8642` → AIAgent loop. The bridge holds two long-lived secrets: an OAuth `client_secret` (used by Claude to obtain access tokens) and `HERMES_API_KEY` (used by the bridge to authenticate to the gateway). Compromise of either one is equivalent to **remote action execution on the host** at the privileges of the user running the gateway.
+`hermes-mcp` is an OAuth-gated bridge: MCP client (Claude Desktop, Claude.ai, Codex CLI, Cursor, ...) → cloudflared/ngrok tunnel → hermes-mcp on `127.0.0.1:8765` → HTTP `/v1/chat/completions` → `hermes-gateway` on `127.0.0.1:8642` → AIAgent loop. The bridge holds two long-lived secrets: an OAuth `client_secret` (used by the MCP client to obtain access tokens) and `HERMES_API_KEY` (used by the bridge to authenticate to the gateway). Compromise of either one is equivalent to **remote action execution on the host** at the privileges of the user running the gateway.
 
 ### Trust boundaries
 
@@ -33,9 +33,9 @@ For the full threat model — including adversary scenarios, design rationale, a
 | `hermes-mcp` server | Trusted | Code under this repo. |
 | `hermes-gateway` server | Trusted | Separate process owned by the same user. The bridge has no sandbox around it. |
 | Tunnel edge (cloudflared / ngrok) | Trusted transport | TLS termination at the edge; we trust them not to MITM. |
-| `OAUTH_CLIENT_SECRET` | Sensitive credential | Treat as a password. Pasted into Claude Desktop. |
+| `OAUTH_CLIENT_SECRET` | Sensitive credential | Treat as a password. Pasted into your MCP client (Claude Desktop, Codex `config.toml`, Cursor `mcp.json`, ...). |
 | `HERMES_API_KEY` | Sensitive credential | Bearer to the gateway. Never leaves the host. |
-| Claude client (Desktop / mobile) | Authenticated | Holds the OAuth credentials and minted access tokens. |
+| MCP client (Claude / Codex / Cursor / ...) | Authenticated | Holds the OAuth credentials and minted access tokens. |
 | Prompts arriving at `hermes_ask` | **Untrusted input** | May be poisoned by injection upstream. |
 
 ### Top risks
@@ -44,12 +44,12 @@ For the full threat model — including adversary scenarios, design rationale, a
 
 2. **Gateway API-key leak.** `HERMES_API_KEY` lets anyone on the host (or its loopback namespace) bypass the bridge entirely and call `/v1/chat/completions` directly. Mitigations: `0600` permissions on `~/.config/hermes-mcp/env`. Run `hermes-mcp` and `hermes-gateway` as a dedicated low-privilege user with no other co-tenants.
 
-3. **Prompt injection via Claude's context.** A webpage or pasted file in a Claude chat tells Claude to call `hermes_ask` with malicious instructions. Mitigations are mostly upstream and user-side:
+3. **Prompt injection via the MCP client's context.** A webpage or pasted file in a chat (Claude, Codex, Cursor, ...) tells the LLM to call `hermes_ask` with malicious instructions. Mitigations are mostly upstream and user-side:
    - Keep Hermes's approval hooks on. Do **not** run with `--yolo`.
    - Configure `platform_toolsets.api_server` in your Hermes config to a narrowly scoped toolset.
    - This bridge cannot reliably detect injection. The user controls Hermes's authorization model.
 
-4. **Authorization-code interception.** Mitigated by mandatory PKCE-S256 and the requirement that `client_secret` accompany the code exchange at `/token`. Codes are single-use (atomic pop on exchange), expire in 60 seconds, and `_StaticClient.validate_redirect_uri` enforces a scheme allowlist (`https`, `http` for localhost only, `claude`, `claudeai`) to prevent `/authorize` becoming an open redirector.
+4. **Authorization-code interception.** Mitigated by mandatory PKCE-S256 and the requirement that `client_secret` accompany the code exchange at `/token`. Codes are single-use (atomic pop on exchange), expire in 60 seconds, and `_StaticClient.validate_redirect_uri` enforces a scheme allowlist (`https` and `http`-on-localhost always; plus operator-configured custom schemes via `OAUTH_ALLOWED_REDIRECT_SCHEMES`, default `claude,claudeai,cursor`) to prevent `/authorize` becoming an open redirector to `javascript:` / `data:` URIs. Operators extending the allowlist are responsible for picking schemes that aren't themselves dangerous.
 
 5. **Refresh-token replay.** Mitigated by atomic-pop-then-mint rotation: a second concurrent `/token` request with the same refresh token finds it gone and is rejected. This also approximates RFC 6819 reuse detection.
 
@@ -61,7 +61,7 @@ For the full threat model — including adversary scenarios, design rationale, a
 
 - Compromise of the host operating system.
 - Compromise of the cloudflared / ngrok account or their infrastructure.
-- Compromise of the user's Claude account (which would let an attacker into the same chats anyway).
+- Compromise of the user's MCP client account (Claude, OpenAI, Cursor, etc.) — would let an attacker into the same chats anyway.
 - Compromise of the `hermes-gateway` process itself (Scenario E in THREAT_MODEL.md).
 
 ## No telemetry

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -73,7 +73,7 @@ Codes are single-use. The pop-then-mint sequence in `exchange_authorization_code
 
 `/authorize` redirects the browser to whatever `redirect_uri` the request supplies (the `redirect_uri` is later required to match at `/token`). PKCE + `client_secret` mean a stolen code cannot be exchanged, so substituting `redirect_uri` does not yield tokens — but it could still turn `/authorize` into an open redirector to dangerous schemes (`javascript:`, `file:`, `data:`).
 
-`_StaticClient.validate_redirect_uri` enforces a scheme allowlist: `https`, `http` (only for localhost), `claude`, and `claudeai`. Any other scheme is rejected before the redirect is constructed.
+`_StaticClient.validate_redirect_uri` enforces a scheme allowlist. The baseline (`https` and `http`-on-localhost) is always allowed; custom URI schemes are operator-configured via the `OAUTH_ALLOWED_REDIRECT_SCHEMES` env var (default `claude,claudeai,cursor`, with `vscode` and others added as new MCP clients are introduced). Any scheme not in the effective allowlist is rejected before the redirect is constructed. Operators who extend the allowlist are responsible for picking schemes that aren't themselves dangerous (`javascript`, `data`, `file`, ...).
 
 ### 4. Refresh-token replay
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "hermes-mcp"
 version = "0.3.0"
-description = "MCP bridge that lets Claude Desktop / Claude mobile delegate tasks to a local Hermes Agent"
+description = "MCP bridge that lets any MCP client (Claude, Codex, Cursor, ...) delegate tasks to a local Hermes Agent"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
@@ -15,6 +15,9 @@ keywords = [
     "mcp-server",
     "claude",
     "claude-mcp",
+    "codex",
+    "cursor",
+    "oauth",
     "hermes",
     "model-context-protocol",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ dev = [
 hermes-mcp = "hermes_mcp.__main__:main"
 
 [project.urls]
-Homepage = "https://github.com/mlennie/claude-hermes-mcp"
-Issues = "https://github.com/mlennie/claude-hermes-mcp/issues"
-Changelog = "https://github.com/mlennie/claude-hermes-mcp/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/mlennie/hermes-mcp"
+Issues = "https://github.com/mlennie/hermes-mcp/issues"
+Changelog = "https://github.com/mlennie/hermes-mcp/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hermes_mcp"]

--- a/src/hermes_mcp/__main__.py
+++ b/src/hermes_mcp/__main__.py
@@ -22,7 +22,8 @@ def _mint_client() -> int:
     print(f"OAUTH_CLIENT_ID={client_id}")
     print(f"OAUTH_CLIENT_SECRET={client_secret}")
     print()
-    print("# Then in Claude Desktop > Settings > Connectors > Add custom connector:")
+    print("# Then in your MCP client (Claude Desktop > Settings > Connectors,")
+    print("# Codex CLI's ~/.codex/config.toml, Cursor's ~/.cursor/mcp.json, ...):")
     print("#   URL:           https://<your-tunnel-host>/mcp")
     print(f"#   Client ID:     {client_id}")
     print(f"#   Client Secret: {client_secret}")
@@ -32,7 +33,7 @@ def _mint_client() -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="hermes-mcp",
-        description="MCP bridge for delegating tasks from Claude to a local Hermes Agent.",
+        description="MCP bridge for delegating tasks from any MCP client to a local Hermes Agent.",
     )
     parser.add_argument("--version", action="version", version=f"hermes-mcp {__version__}")
     parser.add_argument(

--- a/src/hermes_mcp/config.py
+++ b/src/hermes_mcp/config.py
@@ -21,6 +21,9 @@ class ConfigError(Exception):
     """Raised when required configuration is missing or invalid."""
 
 
+DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES: tuple[str, ...] = ("claude", "claudeai", "cursor")
+
+
 @dataclass(frozen=True)
 class Config:
     oauth_client_id: str
@@ -33,6 +36,7 @@ class Config:
     bind_host: str
     bind_port: int
     allowed_hosts: tuple[str, ...]
+    allowed_redirect_schemes: tuple[str, ...]
     log_level: LogLevel
 
     @classmethod
@@ -99,6 +103,18 @@ class Config:
         allowed_hosts_raw = (e.get("MCP_ALLOWED_HOSTS") or "").strip()
         allowed_hosts = tuple(h.strip() for h in allowed_hosts_raw.split(",") if h.strip())
 
+        # OAuth redirect-URI scheme allowlist. Each MCP client uses its own
+        # custom URI scheme for the OAuth redirect (Claude → claude/claudeai,
+        # Cursor → cursor, etc.). The default covers the clients we test
+        # against; operators add to it for new clients.
+        schemes_raw = (e.get("OAUTH_ALLOWED_REDIRECT_SCHEMES") or "").strip()
+        if schemes_raw:
+            allowed_redirect_schemes = tuple(
+                s.strip().lower() for s in schemes_raw.split(",") if s.strip()
+            )
+        else:
+            allowed_redirect_schemes = DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES
+
         log_level_raw = (e.get("LOG_LEVEL") or "INFO").upper()
         if log_level_raw not in _VALID_LOG_LEVELS:
             raise ConfigError(
@@ -127,6 +143,7 @@ class Config:
             bind_host=bind_host,
             bind_port=port,
             allowed_hosts=allowed_hosts,
+            allowed_redirect_schemes=allowed_redirect_schemes,
             log_level=log_level,
         )
 

--- a/src/hermes_mcp/config.py
+++ b/src/hermes_mcp/config.py
@@ -13,15 +13,21 @@ import sys
 from dataclasses import dataclass
 from typing import Literal
 
+from hermes_mcp.oauth import DEFAULT_ALLOWED_REDIRECT_SCHEMES as _DEFAULT_SCHEMES
+
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 _VALID_LOG_LEVELS: frozenset[str] = frozenset(("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"))
+
+# Re-export the canonical default from oauth.py as a sorted tuple. The
+# constant lives in oauth.py because it is fundamentally an OAuth concern;
+# the re-export here gives `test_config` a stable name to assert against
+# and guarantees the env-var default and `StaticClientProvider` default
+# cannot drift apart.
+DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES: tuple[str, ...] = tuple(sorted(_DEFAULT_SCHEMES))
 
 
 class ConfigError(Exception):
     """Raised when required configuration is missing or invalid."""
-
-
-DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES: tuple[str, ...] = ("claude", "claudeai", "cursor")
 
 
 @dataclass(frozen=True)
@@ -106,14 +112,13 @@ class Config:
         # OAuth redirect-URI scheme allowlist. Each MCP client uses its own
         # custom URI scheme for the OAuth redirect (Claude → claude/claudeai,
         # Cursor → cursor, etc.). The default covers the clients we test
-        # against; operators add to it for new clients.
-        schemes_raw = (e.get("OAUTH_ALLOWED_REDIRECT_SCHEMES") or "").strip()
-        if schemes_raw:
-            allowed_redirect_schemes = tuple(
-                s.strip().lower() for s in schemes_raw.split(",") if s.strip()
-            )
-        else:
-            allowed_redirect_schemes = DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES
+        # against; operators add to it for new clients. Any input that
+        # parses to an empty list (whitespace-only, comma-only, etc.) falls
+        # back to the default so a typo can't silently disable every custom
+        # scheme.
+        schemes_raw = e.get("OAUTH_ALLOWED_REDIRECT_SCHEMES") or ""
+        parsed = tuple(s.strip().lower() for s in schemes_raw.split(",") if s.strip())
+        allowed_redirect_schemes = parsed or DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES
 
         log_level_raw = (e.get("LOG_LEVEL") or "INFO").upper()
         if log_level_raw not in _VALID_LOG_LEVELS:

--- a/src/hermes_mcp/hermes_client.py
+++ b/src/hermes_mcp/hermes_client.py
@@ -2,9 +2,9 @@
 
 Each `hermes_ask` call becomes a `POST /v1/chat/completions` to the running
 hermes-gateway (default `http://127.0.0.1:8642`). The gateway runs the same
-`AIAgent.run_conversation` loop that drives Telegram, so Claude — talking
-through this bridge — gets the same brain (skills, sessions, tool
-execution) Hermes already has loaded.
+`AIAgent.run_conversation` loop that drives Telegram, so any MCP client
+(Claude, Codex, Cursor, ...) — talking through this bridge — gets the same
+brain (skills, sessions, tool execution) Hermes already has loaded.
 
 Security:
   - HTTPS-or-localhost; the gateway is bound to 127.0.0.1 by default.

--- a/src/hermes_mcp/oauth.py
+++ b/src/hermes_mcp/oauth.py
@@ -1,8 +1,10 @@
 """Single-user OAuth 2.1 authorization server provider.
 
-The MCP transport spec (and Claude Desktop's Custom Connector UI) require an
-OAuth 2.1 authorization server in front of the MCP endpoint. For a personal
-bridge there is exactly one client and exactly one user, so this provider:
+The MCP transport spec (and most MCP client UIs that add a remote server,
+including Claude Desktop's Custom Connector, Codex CLI, and Cursor) require
+an OAuth 2.1 authorization server in front of the MCP endpoint. For a
+personal bridge there is exactly one client and exactly one user, so this
+provider:
 
   - holds a single static (client_id, client_secret) pair, configured via env
   - auto-approves the /authorize step (security rests on the client_secret
@@ -41,7 +43,7 @@ from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthToken,
 )
-from pydantic import AnyUrl
+from pydantic import AnyUrl, PrivateAttr
 
 logger = logging.getLogger(__name__)
 
@@ -53,28 +55,32 @@ AUTHORIZATION_CODE_TTL = 60  # 1 minute (RFC 6749 §4.1.2 recommends short)
 MAX_OUTSTANDING_AUTH_CODES = 1024
 MAX_OUTSTANDING_ACCESS_TOKENS = 4096
 
-# Redirect-URI schemes the bridge will accept. PKCE + client_secret protect
-# the token exchange, but `/authorize` redirects out to whatever URI the
-# request specifies — we should not let that be a `javascript:`, `file:`,
-# or `data:` URL or anything else that would turn this endpoint into an
-# open redirector to dangerous schemes.
-_ALLOWED_REDIRECT_SCHEMES = frozenset(
-    {
-        "https",
-        "http",  # only honored for localhost; see _check_redirect_uri
-        "claude",
-        "claudeai",
-    }
-)
+# Redirect-URI schemes the bridge ALWAYS accepts as a security baseline.
+# `https` is the standard for hosted MCP clients; `http` is only honored
+# for localhost (enforced below) so testing and the doctor flow work.
+# These are the schemes that cannot turn `/authorize` into an open
+# redirector to dangerous targets.
+_BASELINE_SCHEMES: frozenset[str] = frozenset({"https", "http"})
 
 
-def _check_redirect_uri(redirect_uri: AnyUrl) -> None:
+def _check_redirect_uri(redirect_uri: AnyUrl, allowed_schemes: frozenset[str]) -> None:
     """Reject schemes/hosts that would turn the OAuth flow into an open
-    redirector to dangerous targets. Permissive within sane bounds — we
-    do not pin specific Claude callback URIs because they are subject to
-    change without notice."""
+    redirector to dangerous targets.
+
+    `allowed_schemes` is the union of the baseline (`https`, `http`-on-
+    localhost) and any custom URI schemes the operator configured via
+    `OAUTH_ALLOWED_REDIRECT_SCHEMES`. Each MCP client uses its own custom
+    scheme (`claude`, `claudeai`, `cursor`, `vscode`, ...); the operator
+    adds to the configured list as needed for new clients.
+
+    Permissive within sane bounds — we do not pin specific callback URIs
+    because they are subject to change without notice across client
+    versions. PKCE + `client_secret` protect the actual token exchange;
+    this scheme check just prevents `javascript:` / `data:` / `file:`
+    style open-redirector abuse.
+    """
     scheme = (redirect_uri.scheme or "").lower()
-    if scheme not in _ALLOWED_REDIRECT_SCHEMES:
+    if scheme not in allowed_schemes:
         raise InvalidRedirectUriError(f"redirect_uri scheme {scheme!r} is not allowed")
     if scheme == "http" and redirect_uri.host not in ("localhost", "127.0.0.1", "::1"):
         raise InvalidRedirectUriError("redirect_uri scheme 'http' is only allowed for localhost")
@@ -103,12 +109,21 @@ class _StaticClient(OAuthClientInformationFull):
     Validating the redirect_uri's *scheme* is, however, useful: without it
     `/authorize` would happily redirect to `javascript:` or `data:` URIs
     on request, turning the endpoint into an open redirector.
+
+    `_allowed_redirect_schemes` is the union of the baseline (`https`,
+    `http`-on-localhost) and the operator-configured custom schemes
+    (defaulting to `claude`, `claudeai`, `cursor`). Operators extend the
+    list via `OAUTH_ALLOWED_REDIRECT_SCHEMES` for new MCP clients.
+    Stored as a Pydantic `PrivateAttr` so it does not appear in the
+    serialized model and isn't passed across the wire.
     """
+
+    _allowed_redirect_schemes: frozenset[str] = PrivateAttr(default_factory=frozenset)
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
         if redirect_uri is None:
             raise InvalidRedirectUriError("redirect_uri is required")
-        _check_redirect_uri(redirect_uri)
+        _check_redirect_uri(redirect_uri, self._allowed_redirect_schemes)
         return redirect_uri
 
 
@@ -120,12 +135,18 @@ class StaticClientProvider(
 
     client_id: str
     client_secret: str
+    allowed_redirect_schemes: frozenset[str] = frozenset({"claude", "claudeai", "cursor"})
     access_token_ttl: int = DEFAULT_ACCESS_TOKEN_TTL
     refresh_token_ttl: int = DEFAULT_REFRESH_TOKEN_TTL
 
     def __post_init__(self) -> None:
         if not self.client_id or not self.client_secret:
             raise ValueError("client_id and client_secret are required")
+        # Baseline (`https`, `http`-on-localhost) is always allowed alongside
+        # the operator-configured custom schemes — see _check_redirect_uri.
+        effective_schemes = _BASELINE_SCHEMES | frozenset(
+            s.lower() for s in self.allowed_redirect_schemes
+        )
         self._client = _StaticClient(
             client_id=self.client_id,
             client_secret=self.client_secret,
@@ -134,6 +155,8 @@ class StaticClientProvider(
             response_types=["code"],
             token_endpoint_auth_method="client_secret_post",  # noqa: S106 — RFC 6749 method name, not a secret
         )
+        # PrivateAttr can't be set via constructor in Pydantic v2; assign here.
+        self._client._allowed_redirect_schemes = effective_schemes
         self._auth_codes: dict[str, AuthorizationCode] = {}
         self._access_tokens: dict[str, AccessToken] = {}
         self._refresh_tokens: dict[str, RefreshToken] = {}
@@ -257,7 +280,7 @@ class StaticClientProvider(
         resource: str | None,
     ) -> OAuthToken:
         # Cap outstanding tokens. Under normal operation every token here is
-        # live (Claude refreshes well before expiry); hitting this means
+        # live (MCP clients refresh well before expiry); hitting this means
         # something is wrong (a runaway client) and refusing is the right call.
         if len(self._access_tokens) >= MAX_OUTSTANDING_ACCESS_TOKENS:
             self._reap_expired_access_tokens()

--- a/src/hermes_mcp/oauth.py
+++ b/src/hermes_mcp/oauth.py
@@ -62,6 +62,13 @@ MAX_OUTSTANDING_ACCESS_TOKENS = 4096
 # redirector to dangerous targets.
 _BASELINE_SCHEMES: frozenset[str] = frozenset({"https", "http"})
 
+# Default custom URI schemes the bridge accepts on top of the baseline. Each
+# entry corresponds to an MCP client's OAuth redirect-URI scheme. Operators
+# extend or override this via `OAUTH_ALLOWED_REDIRECT_SCHEMES` for additional
+# clients (e.g. `vscode` for Continue). Re-exported from `config.py` so the
+# server default and the env-var default cannot drift apart.
+DEFAULT_ALLOWED_REDIRECT_SCHEMES: frozenset[str] = frozenset({"claude", "claudeai", "cursor"})
+
 
 def _check_redirect_uri(redirect_uri: AnyUrl, allowed_schemes: frozenset[str]) -> None:
     """Reject schemes/hosts that would turn the OAuth flow into an open
@@ -135,7 +142,7 @@ class StaticClientProvider(
 
     client_id: str
     client_secret: str
-    allowed_redirect_schemes: frozenset[str] = frozenset({"claude", "claudeai", "cursor"})
+    allowed_redirect_schemes: frozenset[str] = DEFAULT_ALLOWED_REDIRECT_SCHEMES
     access_token_ttl: int = DEFAULT_ACCESS_TOKEN_TTL
     refresh_token_ttl: int = DEFAULT_REFRESH_TOKEN_TTL
 

--- a/src/hermes_mcp/server.py
+++ b/src/hermes_mcp/server.py
@@ -51,8 +51,8 @@ logger = logging.getLogger(__name__)
 _TOOL_DESCRIPTION = """\
 Delegate a task to Hermes Agent on this user's mini-PC.
 
-Use this when the user asks for things the calling MCP client cannot do
-directly itself:
+Use this when the user asks for things the calling LLM cannot do directly
+itself:
   - Scheduling cron jobs / recurring tasks
   - Browser-driven web search and scraping
   - Sending email

--- a/src/hermes_mcp/server.py
+++ b/src/hermes_mcp/server.py
@@ -51,7 +51,8 @@ logger = logging.getLogger(__name__)
 _TOOL_DESCRIPTION = """\
 Delegate a task to Hermes Agent on this user's mini-PC.
 
-Use this when the user asks for things Claude cannot do directly itself:
+Use this when the user asks for things the calling MCP client cannot do
+directly itself:
   - Scheduling cron jobs / recurring tasks
   - Browser-driven web search and scraping
   - Sending email
@@ -66,8 +67,10 @@ Args:
   toolsets: Optional. Restrict Hermes to specific toolsets for this call.
   async_mode: Optional. Default False. Decides whether `hermes_ask` blocks
     on the result or returns a job id immediately. Read this carefully —
-    picking wrong on a long task hits a hard ~2-minute Claude tool-call
-    timeout and the user sees "Error occurred during tool execution":
+    picking wrong on a long task hits the MCP client's per-tool-call
+    timeout and the user sees a tool-execution error. Timeouts vary by
+    client (Claude.ai / Claude Desktop is ~2 minutes; Codex CLI, Cursor,
+    and others differ); when uncertain, prefer async.
 
     USE async_mode=True (the safer default for non-trivial work) WHEN ANY
     of these are true about the user's request:
@@ -82,7 +85,7 @@ Args:
       - Tasks that may require user approval on Telegram (those buttons
         add latency unpredictably)
       - You're not sure. False async costs you a polling loop. False sync
-        costs you the whole task hitting the 2-minute cliff and side
+        costs you the whole task hitting the client's timeout and side
         effects (emails sent, files created) being partial and unreported.
 
     USE async_mode=False (sync) ONLY when ALL of these are true:
@@ -145,10 +148,11 @@ IMPORTANT — same caveat as hermes_cancel, but for every job at once:
     Hermes work keeps running until it finishes or hits its 300-second
     timeout. Side effects (emails sent, files created, etc.) happen anyway.
   - **All MCP callers share this job store.** Resetting wipes jobs
-    submitted by other Claude sessions and by any background Hermes-agent
-    workflow that uses this same MCP. Treat it as a global operation, not
-    a per-session one. Confirm with the user before calling it if there
-    is any chance other work is in flight that they care about.
+    submitted by other MCP-client sessions (Claude, Codex, Cursor, etc.)
+    and by any background Hermes-agent workflow that uses this same MCP.
+    Treat it as a global operation, not a per-session one. Confirm with
+    the user before calling it if there is any chance other work is in
+    flight that they care about.
   - Use sparingly. Prefer `hermes_cancel(job_id)` for individual jobs you
     know about. Reach for `hermes_reset` only when the queue is in a state
     you don't want to reason about job-by-job.
@@ -254,6 +258,7 @@ def build_app(
     provider = StaticClientProvider(
         client_id=config.oauth_client_id,
         client_secret=config.oauth_client_secret,
+        allowed_redirect_schemes=frozenset(config.allowed_redirect_schemes),
     )
 
     issuer_url = AnyHttpUrl(config.oauth_issuer_url)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,3 +161,11 @@ def test_allowed_redirect_schemes_replaces_default_when_set() -> None:
 def test_allowed_redirect_schemes_empty_string_falls_back_to_default() -> None:
     cfg = Config.from_env({**VALID_BASE, "OAUTH_ALLOWED_REDIRECT_SCHEMES": "  "})
     assert cfg.allowed_redirect_schemes == ("claude", "claudeai", "cursor")
+
+
+def test_allowed_redirect_schemes_comma_only_falls_back_to_default() -> None:
+    """A typo like `,` or `,,,` would otherwise parse to an empty tuple and
+    silently disable every custom scheme. Treat empty parse result as 'unset'."""
+    for raw in (",", ",,,", " , , ,"):
+        cfg = Config.from_env({**VALID_BASE, "OAUTH_ALLOWED_REDIRECT_SCHEMES": raw})
+        assert cfg.allowed_redirect_schemes == ("claude", "claudeai", "cursor"), raw

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from hermes_mcp.config import Config, ConfigError
+from hermes_mcp.config import (
+    DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES,
+    Config,
+    ConfigError,
+)
 
 VALID_BASE: dict[str, str] = {
     "OAUTH_CLIENT_ID": "hermes-mcp-test",
@@ -74,6 +78,7 @@ def test_minimal_valid_config() -> None:
     assert cfg.bind_host == "127.0.0.1"
     assert cfg.bind_port == 8765
     assert cfg.allowed_hosts == ()
+    assert cfg.allowed_redirect_schemes == DEFAULT_OAUTH_ALLOWED_REDIRECT_SCHEMES
     assert cfg.log_level == "INFO"
 
 
@@ -124,3 +129,35 @@ def test_log_level_validated() -> None:
 def test_log_level_normalized_to_upper() -> None:
     cfg = Config.from_env({**VALID_BASE, "LOG_LEVEL": "debug"})
     assert cfg.log_level == "DEBUG"
+
+
+# --- OAUTH_ALLOWED_REDIRECT_SCHEMES --------------------------------------------
+
+
+def test_allowed_redirect_schemes_defaults_when_unset() -> None:
+    cfg = Config.from_env(VALID_BASE)
+    assert cfg.allowed_redirect_schemes == ("claude", "claudeai", "cursor")
+
+
+def test_allowed_redirect_schemes_parsed_with_whitespace() -> None:
+    cfg = Config.from_env(
+        {**VALID_BASE, "OAUTH_ALLOWED_REDIRECT_SCHEMES": " claude , cursor ,  vscode "}
+    )
+    assert cfg.allowed_redirect_schemes == ("claude", "cursor", "vscode")
+
+
+def test_allowed_redirect_schemes_lowercased() -> None:
+    cfg = Config.from_env({**VALID_BASE, "OAUTH_ALLOWED_REDIRECT_SCHEMES": "Claude,CURSOR"})
+    assert cfg.allowed_redirect_schemes == ("claude", "cursor")
+
+
+def test_allowed_redirect_schemes_replaces_default_when_set() -> None:
+    """Explicit env var fully replaces the default — it's not additive.
+    Operators who want claude+claudeai+cursor+vscode must list all four."""
+    cfg = Config.from_env({**VALID_BASE, "OAUTH_ALLOWED_REDIRECT_SCHEMES": "vscode"})
+    assert cfg.allowed_redirect_schemes == ("vscode",)
+
+
+def test_allowed_redirect_schemes_empty_string_falls_back_to_default() -> None:
+    cfg = Config.from_env({**VALID_BASE, "OAUTH_ALLOWED_REDIRECT_SCHEMES": "  "})
+    assert cfg.allowed_redirect_schemes == ("claude", "claudeai", "cursor")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,8 +22,11 @@ def test_mint_client_prints_credentials(capsys: pytest.CaptureFixture[str]) -> N
     out = capsys.readouterr().out
     assert "OAUTH_CLIENT_ID=hermes-mcp-" in out
     assert "OAUTH_CLIENT_SECRET=" in out
-    # Should also include the Claude Desktop paste-block hint.
-    assert "custom connector" in out.lower()
+    # Should include a hint pointing at MCP clients to paste these into.
+    lowered = out.lower()
+    assert "mcp client" in lowered
+    # Mention at least one specific client to make the hint actionable.
+    assert any(c in lowered for c in ("claude desktop", "codex", "cursor"))
 
 
 def test_missing_required_env_returns_2(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -83,12 +83,64 @@ def test_validate_redirect_uri_allows_expected_schemes() -> None:
     client = cast(OAuthClientInformationFull, asyncio.run(p.get_client(CLIENT_ID)))
     # Public-suffix HTTPS URLs.
     assert client.validate_redirect_uri(AnyUrl("https://app.example.com/cb")) is not None
-    # Claude Desktop's private-use schemes.
+    # Default custom schemes covering Claude Desktop / Claude.ai / Cursor.
     assert client.validate_redirect_uri(AnyUrl("claude://oauth/callback")) is not None
     assert client.validate_redirect_uri(AnyUrl("claudeai://oauth/callback")) is not None
+    assert client.validate_redirect_uri(AnyUrl("cursor://anysphere.cursor-mcp/cb")) is not None
     # http only on localhost.
     assert client.validate_redirect_uri(AnyUrl("http://localhost:9999/x")) is not None
     assert client.validate_redirect_uri(AnyUrl("http://127.0.0.1:9999/x")) is not None
+
+
+def test_validate_redirect_uri_rejects_scheme_not_in_default_allowlist() -> None:
+    """A custom scheme not in the default set (e.g. `vscode://`) is rejected
+    unless the operator adds it to OAUTH_ALLOWED_REDIRECT_SCHEMES."""
+    p = _provider()
+    client = cast(OAuthClientInformationFull, asyncio.run(p.get_client(CLIENT_ID)))
+    with pytest.raises(InvalidRedirectUriError, match="not allowed"):
+        client.validate_redirect_uri(AnyUrl("vscode://continue.continue/oauth/callback"))
+
+
+def test_validate_redirect_uri_accepts_custom_scheme_when_configured() -> None:
+    """Operator adds `vscode` to OAUTH_ALLOWED_REDIRECT_SCHEMES → accepted."""
+    p = StaticClientProvider(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        allowed_redirect_schemes=frozenset({"vscode"}),
+    )
+    client = cast(OAuthClientInformationFull, asyncio.run(p.get_client(CLIENT_ID)))
+    assert (
+        client.validate_redirect_uri(AnyUrl("vscode://continue.continue/oauth/callback"))
+        is not None
+    )
+
+
+def test_validate_redirect_uri_baseline_always_allowed_regardless_of_config() -> None:
+    """`https` and `http`-on-localhost are baseline schemes; they're allowed
+    even if the operator configures an allowlist that excludes them. This is
+    the security floor for Codex CLI's HTTPS callbacks and for local testing."""
+    p = StaticClientProvider(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        allowed_redirect_schemes=frozenset({"vscode"}),  # deliberately omits https/http
+    )
+    client = cast(OAuthClientInformationFull, asyncio.run(p.get_client(CLIENT_ID)))
+    assert client.validate_redirect_uri(AnyUrl("https://app.example.com/cb")) is not None
+    assert client.validate_redirect_uri(AnyUrl("http://localhost:9999/cb")) is not None
+
+
+def test_validate_redirect_uri_default_claude_schemes_rejected_under_custom_config() -> None:
+    """If the operator explicitly configures schemes without `claude`/`claudeai`,
+    those schemes are no longer accepted — the env var fully replaces the
+    default custom-scheme list (baseline stays intact)."""
+    p = StaticClientProvider(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        allowed_redirect_schemes=frozenset({"cursor"}),  # only cursor; no claude
+    )
+    client = cast(OAuthClientInformationFull, asyncio.run(p.get_client(CLIENT_ID)))
+    with pytest.raises(InvalidRedirectUriError, match="not allowed"):
+        client.validate_redirect_uri(AnyUrl("claude://oauth/callback"))
 
 
 def test_validate_redirect_uri_rejects_dangerous_schemes() -> None:

--- a/tests/test_server_smoke.py
+++ b/tests/test_server_smoke.py
@@ -10,6 +10,8 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
+from mcp.shared.auth import InvalidRedirectUriError
+from pydantic import AnyUrl
 
 from hermes_mcp.config import Config
 from hermes_mcp.hermes_client import HermesError
@@ -96,6 +98,27 @@ def test_allowed_hosts_origins_handle_scheme_prefix() -> None:
     assert "https://hermes.example.com" in origins
     assert "https://other.example.com" in origins
     assert "https://https://other.example.com" not in origins
+
+
+def test_oauth_allowed_schemes_propagate_from_env_to_validation() -> None:
+    """End-to-end wiring check: `OAUTH_ALLOWED_REDIRECT_SCHEMES` set on the
+    env reaches `_StaticClient.validate_redirect_uri` through Config →
+    build_app → StaticClientProvider → _StaticClient. The two unit tests in
+    test_config.py and test_oauth.py cover the parts in isolation; this
+    catches a regression that breaks the wiring between them."""
+    cfg = Config.from_env({**VALID_ENV, "OAUTH_ALLOWED_REDIRECT_SCHEMES": "vscode"})
+    mcp = build_app(cfg, MagicMock())
+    provider = mcp._auth_server_provider  # type: ignore[attr-defined]
+    assert provider is not None
+    client = provider._client  # type: ignore[attr-defined]
+    # Configured scheme works end-to-end.
+    assert client.validate_redirect_uri(AnyUrl("vscode://continue.continue/cb")) is not None
+    # Baseline survives even when default custom schemes are not configured.
+    assert client.validate_redirect_uri(AnyUrl("https://app.example.com/cb")) is not None
+    # Default custom schemes are NOT accepted when the env var is set to
+    # something else — pins the "env var replaces, not extends" contract.
+    with pytest.raises(InvalidRedirectUriError, match="not allowed"):
+        client.validate_redirect_uri(AnyUrl("claude://oauth/cb"))
 
 
 def test_oauth_issuer_url_no_double_slash_in_resource_url() -> None:


### PR DESCRIPTION
## Summary

Removes the Claude-only assumptions baked into the OAuth flow, tool descriptions, and docs so OpenAI Codex CLI, Cursor, Continue, and any other MCP client that speaks **Streamable HTTP + OAuth 2.1** can connect to the same bridge.

**Code:**
- New env var `OAUTH_ALLOWED_REDIRECT_SCHEMES` (default `claude,claudeai,cursor`): comma-separated list of OAuth redirect-URI custom schemes to accept. `https` and `http`-on-localhost are always allowed as a security baseline. Operators extend the list for new clients without patching the code.
- `oauth.py`: scheme allowlist is now instance-scoped on `_StaticClient` (Pydantic `PrivateAttr`); baseline always-allowed schemes are enforced regardless of operator configuration.
- `server.py`: tool descriptions for `hermes_ask` / `hermes_check` / `hermes_cancel` / `hermes_reset` are now client-neutral. Async-mode timeout guidance now notes that enforcement varies by client (Claude.ai ~2 min; Codex CLI, Cursor, others differ).

**Docs:**
- README: reframed as multi-client; new **Client compatibility** section with paste-ready config snippets for Claude Desktop, Codex CLI (`~/.codex/config.toml`), and Cursor (`~/.cursor/mcp.json`). Documented the new env var in the configuration table.
- CLAUDE.md, `.env.example`, SECURITY.md, THREAT_MODEL.md, `pyproject.toml`, mint-client output, and source docstrings: generalized to refer to MCP clients rather than Claude specifically.

## No breaking changes

Existing Claude-only setups continue to work without any config change. The default `OAUTH_ALLOWED_REDIRECT_SCHEMES` value is a superset of the previously hardcoded set (`claude,claudeai` + adds `cursor`).

## Test plan

- [x] 9 new tests (5 in `test_config.py` for env-var parsing, 4 in `test_oauth.py` for configurable allowlist + baseline-always-allowed invariant)
- [x] `test_main.py` updated to match new mint-client output wording
- [x] Full suite: **130/130 pass** (was 121)
- [x] `ruff check` + `ruff format --check` + `mypy src/` all clean
- [x] Manual smoke: `pipx install --force` + `systemctl --user restart hermes-mcp` on live bridge. All 4 tools register; `allowed_redirect_schemes` loads from default; `claude://`, `claudeai://`, `cursor://`, `https://`, `http://localhost` all accepted; `javascript://` rejected.
- [ ] **End-to-end Codex CLI test** — requires user-side setup; deferred to post-merge. Plan: configure `~/.codex/config.toml` pointing at the existing tunnel + OAuth credentials, complete handshake, call `hermes_ask`.
- [ ] **Claude regression in live MCP client** — recommended check before merge.

## Out of scope (deferred)

- Stdio MCP transport (separate deployment model; remote-via-tunnel stays the only supported architecture in this PR)
- Repo/package rename
- Multi-client OAuth credentials (one `client_id`/`client_secret` continues to serve all clients)
- Per-client docs in `docs/clients/`
